### PR TITLE
Add bug report issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Fill out a bug report to help us improve Buildamic.
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Bug Description
+
+## How to Reproduce
+
+## Extra Detail
+<!-- Screenshots, template code, or exception error message/link -->
+
+## Environment
+<!-- You can copy/paste the output of `php please support:details` here -->


### PR DESCRIPTION
Adds a bug report template similar to the one that Statamic uses to keep bugs organised, and to minimize the chance of getting bug reports that are missing information.